### PR TITLE
add a warning for small number of probes

### DIFF
--- a/R/houseman.R
+++ b/R/houseman.R
@@ -89,6 +89,15 @@ adjust.beta = function(B, top_n=500, mc.cores=2,
     stopifnot(all((B > 0) & (B < 1), na.rm=TRUE))
 
     if(is.null(cell.coefs)){
+      if(nrow(B) <= 200000){
+        if(length(grep("^cg", rownames(B), value=TRUE, perl=TRUE)) >=
+           length(grep("^chr", rownames(B), value=TRUE, perl=TRUE))){
+          cell.coefs = system.file("extdata", "houseman-dmrs.txt", package="celltypes450")
+        } else {
+          cell.coefs = system.file("extdata", "houseman-dmrs-locs.txt", package="celltypes450")
+        }
+        warning("We suggest you use at least 2x10^5 probes")
+      }
         # rownames are cg id.
         if(length(grep("^cg", rownames(B), value=TRUE, perl=TRUE)) > 200000){
             cell.coefs = system.file("extdata", "houseman-dmrs.txt", package="celltypes450")


### PR DESCRIPTION
For a small number of probes, it will default to cg id or chr id, depending on what appears more often in the row names of the data, and then issue a warning. However, there is still the possibility of having more than 2x10^5 probes, but less than 2x10^5 of them with a cg id, which could cause problems. 